### PR TITLE
Allow control of MOUNTPOINT and of root for operations

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,13 +1,14 @@
 export POOL="tank"
 export DATASET="$POOL/fish"
-export MOUNTPOINT="/$DATASET"
+export MOUNTPOINT=${MOUNTPOINT:-"/$DATASET"}
+export ROOTDIR=${ROOTDIR:-"/$MOUNTPOINT"}
 export MAX_FILENAME_LEN=255
 export ZFS=${ZFS:-"/sbin/zfs"}
 export ZPOOL=${ZPOOL:-"/sbin/zpool"}
 export EXPORT_COOKIE=${EXPORT_COOKIE:-`mktemp -t XXXXXXXX`}
 
 # Write up to MAX_WRITE_SIZE bytes to randomly selected files
-# in the root of $DATASET.
+# in the root of $MOUNTPOINT (by default, $DATASET).
 export MAX_WRITE_SIZE=$(( 4 * 1024 * 1024 ))
 
 # Randomly select values for these properties when creating
@@ -159,7 +160,7 @@ rand_compression()
 
 rand_directory()
 {
-	local TOP=${1:-$MOUNTPOINT}
+	local TOP=${1:-$ROOTDIR}
 	DIRS=(`$SUDO find $TOP -type d`)
 	echo ${DIRS[$(( $RANDOM % ${#DIRS[@]}))]}
 }

--- a/randimportexport.sh
+++ b/randimportexport.sh
@@ -17,6 +17,6 @@ while :; do
 		sleep 1
 	done
 	clear_export_flag
-	$SUDO rm -f $MOUNTPOINT/* $MOUNTPOINT/.*
+	$SUDO rm -f $ROOTDIR/* $ROOTDIR/.*
 	$SUDO $ZPOOL import $ZPOOL_IMPORT_OPT $POOL
 done

--- a/randrm.sh
+++ b/randrm.sh
@@ -14,7 +14,7 @@ while :; do
 	randsleep 60
 	wait_for_mount $MOUNTPOINT
 	wait_for_export
-	find $MOUNTPOINT -mindepth 1 | while read f ; do
+	find $ROOTDIR -mindepth 1 | while read f ; do
 		if coinflip 33 ; then
 			$SUDO rm -rf "$f"
 		fi

--- a/randwrite.sh
+++ b/randwrite.sh
@@ -16,7 +16,7 @@ while :; do
 	wait_for_export
 	# Truncate each file to 0 with 2/3 probability, otherwise
 	# write up to MAX_WRITE_SIZE to it.
-	find $MOUNTPOINT -type f | while read f ; do
+	find $ROOTDIR -type f | while read f ; do
 		wait_for_mount $MOUNTPOINT
 		if coinflip 66 ; then
 			$SUDO dd if=/dev/null of="$f"

--- a/randxattr.sh
+++ b/randxattr.sh
@@ -14,7 +14,7 @@ while :; do
 	randsleep 60
 
 	wait_for_export
-	find $MOUNTPOINT | while read f ; do
+	find $ROOTDIR | while read f ; do
 		if coinflip 50 ; then
 			v=`randbase64`
 			n=$(mktemp -u `perl -e 'print "X" x int rand 247 + 1'`)


### PR DESCRIPTION
If $MOUNTPOINT is set, use that value instead of calculating it based on
$DATASET.  This allows the test script to be used for testing
filesystems with different semantics and mountpoint conventions than
ZFS.

If $ROOTDIR is set, perform operations there instead of $MOUNTPOINT.
This allows files and directories created by the testing to be
segregated, both for easy cleanup and to prevent files that might not be
disposable from being removed by the test.