### PR TITLE
B control rootdir and add runmany

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,13 +1,15 @@
 export POOL="tank"
 export DATASET="$POOL/fish"
-export MOUNTPOINT="/$DATASET"
+export LOGDIR=${LOGDIR:-"./"}
+export MOUNTPOINT=${MOUNTPOINT:-"/$DATASET"}
+export ROOTDIR=${ROOTDIR:-"/$MOUNTPOINT"}
 export MAX_FILENAME_LEN=255
 export ZFS=${ZFS:-"/sbin/zfs"}
 export ZPOOL=${ZPOOL:-"/sbin/zpool"}
 export EXPORT_COOKIE=${EXPORT_COOKIE:-`mktemp -t XXXXXXXX`}
 
 # Write up to MAX_WRITE_SIZE bytes to randomly selected files
-# in the root of $DATASET.
+# in the root of $MOUNTPOINT (by default, $DATASET).
 export MAX_WRITE_SIZE=$(( 4 * 1024 * 1024 ))
 
 # Randomly select values for these properties when creating
@@ -159,7 +161,7 @@ rand_compression()
 
 rand_directory()
 {
-	local TOP=${1:-$MOUNTPOINT}
+	local TOP=${1:-$ROOTDIR}
 	DIRS=(`$SUDO find $TOP -type d`)
 	echo ${DIRS[$(( $RANDOM % ${#DIRS[@]}))]}
 }

--- a/randimportexport.sh
+++ b/randimportexport.sh
@@ -17,6 +17,6 @@ while :; do
 		sleep 1
 	done
 	clear_export_flag
-	$SUDO rm -f $MOUNTPOINT/* $MOUNTPOINT/.*
+	$SUDO rm -f $ROOTDIR/* $ROOTDIR/.*
 	$SUDO $ZPOOL import $ZPOOL_IMPORT_OPT $POOL
 done

--- a/randrm.sh
+++ b/randrm.sh
@@ -14,7 +14,7 @@ while :; do
 	randsleep 60
 	wait_for_mount $MOUNTPOINT
 	wait_for_export
-	find $MOUNTPOINT -mindepth 1 | while read f ; do
+	find $ROOTDIR -mindepth 1 | while read f ; do
 		if coinflip 33 ; then
 			$SUDO rm -rf "$f"
 		fi

--- a/randwrite.sh
+++ b/randwrite.sh
@@ -16,7 +16,7 @@ while :; do
 	wait_for_export
 	# Truncate each file to 0 with 2/3 probability, otherwise
 	# write up to MAX_WRITE_SIZE to it.
-	find $MOUNTPOINT -type f | while read f ; do
+	find $ROOTDIR -type f | while read f ; do
 		wait_for_mount $MOUNTPOINT
 		if coinflip 66 ; then
 			$SUDO dd if=/dev/null of="$f"

--- a/randxattr.sh
+++ b/randxattr.sh
@@ -14,7 +14,7 @@ while :; do
 	randsleep 60
 
 	wait_for_export
-	find $MOUNTPOINT | while read f ; do
+	find $ROOTDIR | while read f ; do
 		if coinflip 50 ; then
 			v=`randbase64`
 			n=$(mktemp -u `perl -e 'print "X" x int rand 247 + 1'`)

--- a/runstress.sh
+++ b/runstress.sh
@@ -11,38 +11,29 @@ fi
 pushd $basedir > /dev/null
 
 # Run more instances to increase stress level.
-./randcreate.sh < /dev/null > ${LOGDIR}/randcreate.log 2>&1 &
-./randcreate.sh < /dev/null > ${LOGDIR}/randcreate2.log 2>&1 &
 
-./randwrite.sh < /dev/null > ${LOGDIR}/randwrite.log 2>&1 &
-./randwrite.sh < /dev/null > ${LOGDIR}/randwrite2.log 2>&1 &
+# User operations
+runmany 2 ./randcreate.sh
+runmany 2 ./randwrite.sh
+runmany 2 ./randrm.sh
+runmany 2 ./randxattr.sh
+runmany 2 ./randsymlink.sh
+runmany 2 ./randmkdir.sh
 
-./randrm.sh < /dev/null > ${LOGDIR}/randrm.log 2>&1 &
-./randrm.sh < /dev/null > ${LOGDIR}/randrm2.log 2>&1 &
-
-./randxattr.sh < /dev/null > ${LOGDIR}/randxattr.log 2>&1 &
-./randxattr.sh < /dev/null > ${LOGDIR}/randxattr2.log 2>&1 &
-
-./randsymlink.sh < /dev/null > ${LOGDIR}/randsymlink.log 2>&1 &
-./randsymlink.sh < /dev/null > ${LOGDIR}/randsymlink2.log 2>&1 &
-
-./randmkdir.sh < /dev/null > ${LOGDIR}/randmkdir.log 2>&1 &
-./randmkdir.sh < /dev/null > ${LOGDIR}/randmkdir2.log 2>&1 &
-
-# Pool operations.
-./randimportexport.sh < /dev/null > ${LOGDIR}/randimportexport.log 2>&1 &
-./randscrub.sh < /dev/null > ${LOGDIR}/randscrub.log 2>&1 &
+## Pool operations.
+runmany 1 ./randimportexport.sh
+runmany 1 ./randscrub.sh
 
 # Dataset operations.
-./randsnapshot.sh < /dev/null > ${LOGDIR}/randsnapshot.log 2>&1 &
-./randdataset.sh < /dev/null > ${LOGDIR}/randdataset.log 2>&1 &
-./randsendrecv.sh < /dev/null > ${LOGDIR}/randsendrecv.log 2>&1 &
+runmany 1 ./randsnapshot.sh
+runmany 1 ./randdataset.sh
+runmany 1 ./randsendrecv.sh
 
 # Randomly change dataset properties.
-./randproprecordsize.sh < /dev/null > ${LOGDIR}/randproprecordsize.log 2>&1 &
-./randpropdnodesize.sh < /dev/null > ${LOGDIR}/randpropdnodesize.log 2>&1 &
-./randpropxattr.sh < /dev/null > ${LOGDIR}/randpropxattr.log 2>&1 &
-./randpropcompression.sh < /dev/null > ${LOGDIR}/randpropcompression.log 2>&1 &
+runmany 1 ./randproprecordsize.sh
+runmany 1 ./randpropdnodesize.sh
+runmany 1 ./randpropxattr.sh
+runmany 1 ./randpropcompression.sh
 
 popd > /dev/null
 

--- a/runstress.sh
+++ b/runstress.sh
@@ -11,38 +11,38 @@ fi
 pushd $basedir > /dev/null
 
 # Run more instances to increase stress level.
-./randcreate.sh < /dev/null > randcreate.log 2>&1 &
-./randcreate.sh < /dev/null > randcreate2.log 2>&1 &
+./randcreate.sh < /dev/null > ${LOGDIR}/randcreate.log 2>&1 &
+./randcreate.sh < /dev/null > ${LOGDIR}/randcreate2.log 2>&1 &
 
-./randwrite.sh < /dev/null > randwrite.log 2>&1 &
-./randwrite.sh < /dev/null > randwrite2.log 2>&1 &
+./randwrite.sh < /dev/null > ${LOGDIR}/randwrite.log 2>&1 &
+./randwrite.sh < /dev/null > ${LOGDIR}/randwrite2.log 2>&1 &
 
-./randrm.sh < /dev/null > randrm.log 2>&1 &
-./randrm.sh < /dev/null > randrm2.log 2>&1 &
+./randrm.sh < /dev/null > ${LOGDIR}/randrm.log 2>&1 &
+./randrm.sh < /dev/null > ${LOGDIR}/randrm2.log 2>&1 &
 
-./randxattr.sh < /dev/null > randxattr.log 2>&1 &
-./randxattr.sh < /dev/null > randxattr2.log 2>&1 &
+./randxattr.sh < /dev/null > ${LOGDIR}/randxattr.log 2>&1 &
+./randxattr.sh < /dev/null > ${LOGDIR}/randxattr2.log 2>&1 &
 
-./randsymlink.sh < /dev/null > randsymlink.log 2>&1 &
-./randsymlink.sh < /dev/null > randsymlink2.log 2>&1 &
+./randsymlink.sh < /dev/null > ${LOGDIR}/randsymlink.log 2>&1 &
+./randsymlink.sh < /dev/null > ${LOGDIR}/randsymlink2.log 2>&1 &
 
-./randmkdir.sh < /dev/null > randmkdir.log 2>&1 &
-./randmkdir.sh < /dev/null > randmkdir2.log 2>&1 &
+./randmkdir.sh < /dev/null > ${LOGDIR}/randmkdir.log 2>&1 &
+./randmkdir.sh < /dev/null > ${LOGDIR}/randmkdir2.log 2>&1 &
 
 # Pool operations.
-./randimportexport.sh < /dev/null > randimportexport.log 2>&1 &
-./randscrub.sh < /dev/null > randscrub.log 2>&1 &
+./randimportexport.sh < /dev/null > ${LOGDIR}/randimportexport.log 2>&1 &
+./randscrub.sh < /dev/null > ${LOGDIR}/randscrub.log 2>&1 &
 
 # Dataset operations.
-./randsnapshot.sh < /dev/null > randsnapshot.log 2>&1 &
-./randdataset.sh < /dev/null > randdataset.log 2>&1 &
-./randsendrecv.sh < /dev/null > randsendrecv.log 2>&1 &
+./randsnapshot.sh < /dev/null > ${LOGDIR}/randsnapshot.log 2>&1 &
+./randdataset.sh < /dev/null > ${LOGDIR}/randdataset.log 2>&1 &
+./randsendrecv.sh < /dev/null > ${LOGDIR}/randsendrecv.log 2>&1 &
 
 # Randomly change dataset properties.
-./randproprecordsize.sh < /dev/null > randproprecordsize.log 2>&1 &
-./randpropdnodesize.sh < /dev/null > randpropdnodesize.log 2>&1 &
-./randpropxattr.sh < /dev/null > randpropxattr.log 2>&1 &
-./randpropcompression.sh < /dev/null > randpropcompression.log 2>&1 &
+./randproprecordsize.sh < /dev/null > ${LOGDIR}/randproprecordsize.log 2>&1 &
+./randpropdnodesize.sh < /dev/null > ${LOGDIR}/randpropdnodesize.log 2>&1 &
+./randpropxattr.sh < /dev/null > ${LOGDIR}/randpropxattr.log 2>&1 &
+./randpropcompression.sh < /dev/null > ${LOGDIR}/randpropcompression.log 2>&1 &
 
 popd > /dev/null
 


### PR DESCRIPTION
1)  Allow control of MOUNTPOINT and of root for operations

    If $MOUNTPOINT is set, use that value instead of calculating it based on
    $DATASET.  This allows the test script to be used for testing
    filesystems with different mountpoint conventions than ZFS.

    If $ROOTDIR is set, perform operations there instead of $MOUNTPOINT.
    This allows files and directories created by the testing to be
    segregated, both for easy cleanup and to prevent files on the file
    system that might not be disposable, from being removed by the test.

    Previously, logs were always placed in the same directory as
    runstress.sh (and other) scripts.  This change allows the user to set
    LOGDIR, in which case the log files will be placed there.

2)  Add runmany() to automate executing the individual scripts in zfsstress

    runmany <count> <cmd> runs a script <count> times,
    directing stdout and stderr to ${LOGDIR}/${CMD}.$x.log
    where $x is the instance number from 1..<count>.

    Use this in runstress to eliminate redundant code
    and make it easier to increase the number of instances
    of a given script that are run.