### PR TITLE
Use default for randsleep

### DIFF
--- a/randcreate.sh
+++ b/randcreate.sh
@@ -18,5 +18,5 @@ while :; do
 		file="`randstring $(( 1 + $RANDOM % $MAX_FILENAME_LEN ))`"
 		$SUDO touch "$parent/$file"
 	done
-	randsleep 60
+	randsleep
 done

--- a/randdataset.sh
+++ b/randdataset.sh
@@ -12,7 +12,7 @@ set -x
 
 
 while :; do
-	randsleep 60
+	randsleep
 
 	# Create some datasets then randomly destroy datasets
 	# with 50% probability.

--- a/randmkdir.sh
+++ b/randmkdir.sh
@@ -18,5 +18,5 @@ while :; do
 		newdir="`randstring $(( 1 + $RANDOM % $MAX_FILENAME_LEN ))`"
 		$SUDO mkdir "$parent/$newdir"
 	done
-	randsleep 60
+	randsleep
 done

--- a/randpropcompression.sh
+++ b/randpropcompression.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 	$SUDO $ZFS list -H -o name -t filesystem |
 		grep -e "^$DATASET$" -e "^$DATASET/" |
 	while read ds ; do

--- a/randpropdnodesize.sh
+++ b/randpropdnodesize.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 	$SUDO $ZFS list -H -o name -t filesystem |
 		grep -e "^$DATASET$" -e "^$DATASET/" |
 	while read ds ; do

--- a/randproprecordsize.sh
+++ b/randproprecordsize.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 	$SUDO $ZFS list -H -o name -t filesystem |
 		grep -e "^$DATASET$" -e "^$DATASET/" |
 	while read ds ; do

--- a/randpropxattr.sh
+++ b/randpropxattr.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 	$SUDO $ZFS list -H -o name -t filesystem |
 		grep -e "^$DATASET$" -e "^$DATASET/" |
 	while read ds ; do

--- a/randrm.sh
+++ b/randrm.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 	wait_for_mount $MOUNTPOINT
 	wait_for_export
 	find $MOUNTPOINT -mindepth 1 | while read f ; do

--- a/randscrub.sh
+++ b/randscrub.sh
@@ -10,6 +10,6 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 	$SUDO $ZPOOL scrub $POOL
 done

--- a/randsendrecv.sh
+++ b/randsendrecv.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 
 	# Pick a random snapshot and send/recv it to a new
 	# dataset in the pool. This relies on snapshots being

--- a/randsnapshot.sh
+++ b/randsnapshot.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 
 	# Creat a snapshot then randomly destroy snapshots
 	# with 50% probability.

--- a/randsymlink.sh
+++ b/randsymlink.sh
@@ -19,5 +19,5 @@ while :; do
 		target=$( randstring $(( 1 + $RANDOM % 4096 )) )
 		$SUDO ln -sf "$target" "$link"
 	done
-	randsleep 60
+	randsleep
 done

--- a/randwrite.sh
+++ b/randwrite.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 	wait_for_mount $MOUNTPOINT
 	wait_for_export
 	# Truncate each file to 0 with 2/3 probability, otherwise

--- a/randxattr.sh
+++ b/randxattr.sh
@@ -11,7 +11,7 @@ fi
 set -x
 
 while :; do
-	randsleep 60
+	randsleep
 
 	wait_for_export
 	find $MOUNTPOINT | while read f ; do


### PR DESCRIPTION
Most functions loop with a sleep of random duration (up to some maximum)
once per iteration.

The randsleep function has a default maximum of 60 seconds, but the
functions were specifying a maximum sleep time of 60 seconds anyway.

This commit changes those functions not to specify a maximum and use the
default, so the sleep time of all functions can be adjusted by altering
a single value.