### PR TITLE
Sometimes choose existing files or dirs as symlink target

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -157,6 +157,15 @@ rand_compression()
 	echo ${ALG[$(( $RANDOM % ${#ALG[@]}))]}
 }
 
+rand_file()
+{
+	local local_root=$(rand_directory)
+	FILES=(`$SUDO find $local_root -type f`)
+	if [[ ${#FILES[@]} -gt 0 ]]; then
+		echo ${FILES[$(( $RANDOM % ${#FILES[@]}))]}
+	fi
+}
+
 rand_directory()
 {
 	local TOP=${1:-$MOUNTPOINT}

--- a/randsymlink.sh
+++ b/randsymlink.sh
@@ -16,7 +16,13 @@ while :; do
 		wait_for_export
 		parent=`rand_directory`
 		link=$parent/$( randstring $(( 1 + $RANDOM % 255 )) )
-		target=$( randstring $(( 1 + $RANDOM % 4096 )) )
+		if coinflip 33 ; then
+			target=$( randstring $(( 1 + $RANDOM % 4096 )) )
+		elif coinflip 50 ; then
+			target=$( rand_file )
+		else
+			target=$( rand_directory )
+		fi
 		$SUDO ln -sf "$target" "$link"
 	done
 	randsleep 60


### PR DESCRIPTION
Sometimes choose an existing file or directory as the target of a
symlink.  In the past, symlink targets were always a newly-generated
paths and likely did not exist.