### PR TITLE
Correct division by zero error in rand_directory

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -161,7 +161,11 @@ rand_directory()
 {
 	local TOP=${1:-$MOUNTPOINT}
 	DIRS=(`$SUDO find $TOP -type d`)
-	echo ${DIRS[$(( $RANDOM % ${#DIRS[@]}))]}
+	if [[ ${#DIRS[@]} -gt 0 ]]; then
+		echo ${DIRS[$(( $RANDOM % ${#DIRS[@]}))]}
+	else
+		echo $TOP
+	fi
 }
 
 rand_dataset()


### PR DESCRIPTION
If the find command returns no directories, do not attempt
to randomly choose one of them.  Return the root used for
the find.