### PR TITLE
Simplify for loop iteration termination conditions

### DIFF
--- a/randcreate.sh
+++ b/randcreate.sh
@@ -11,7 +11,8 @@ fi
 set -x
 
 while :; do
-	for ((i=0; i< $(( $RANDOM % 256 )); i++)) ; do
+	let loops=$(( $RANDOM % 256 ))
+	for ((i=0; i< ${loops} ; i++)) ; do
 		wait_for_mount $MOUNTPOINT
 		wait_for_export
 		parent=`rand_directory`

--- a/randdataset.sh
+++ b/randdataset.sh
@@ -16,7 +16,8 @@ while :; do
 
 	# Create some datasets then randomly destroy datasets
 	# with 50% probability.
-	for ((i=0; i< $(( $RANDOM % 64 )); i++)) ; do
+	let loops=$(( $RANDOM % 64 ))
+	for ((i=0; i< ${loops} ; i++)) ; do
 		parent=`rand_dataset`
 		ds=$(mktemp -u `perl -e 'print "X" x int rand 255 + 1'`)
 		ZFS_CREATE_OPT=""

--- a/randmkdir.sh
+++ b/randmkdir.sh
@@ -11,7 +11,8 @@ fi
 set -x
 
 while :; do
-	for ((i=0; i< $(( $RANDOM % 64 )); i++)) ; do
+	let loops=$(( $RANDOM % 64 ))
+	for ((i=0; i< ${loops} ; i++)) ; do
 		wait_for_mount $MOUNTPOINT
 		wait_for_export
 		parent=`rand_directory`

--- a/randsymlink.sh
+++ b/randsymlink.sh
@@ -11,7 +11,8 @@ fi
 set -x
 
 while :; do
-	for ((i=0; i< $(( $RANDOM % 256 )); i++)) ; do
+	let loops=$(( $RANDOM % 256 ))
+	for ((i=0; i< ${loops} ; i++)) ; do
 		wait_for_mount $MOUNTPOINT
 		wait_for_export
 		parent=`rand_directory`


### PR DESCRIPTION
Several tests use a for() loop to perform some action a random number of
times.

The termination condition of the loops contained a reference to $RANDOM.
Because this expression is evaluated after each pass through the loop,
the index was compared against a different random number each time.  The
actual behavior was thus more like a while() loop with a random
termination condition than a typical for loop.

This patch evalutes $RANDOM once to determine the number of passes
through the loop, so the code's behavior is more obvious.