### PR TITLE
use $(hostname) instead of ${HOSTNAME} for log names

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -39,7 +39,7 @@ runmany()
 	local logname
 	set -x
 	for instance in $(seq $COUNT); do
-		logname="${LOGDIR}/${CMD}.${HOSTNAME}.$$.${instance}.log"
+		logname="${LOGDIR}/${CMD}.$(hostname).$$.${instance}.log"
 		$CMD < /dev/null > ${logname} 2>&1 &
 	done
 	set +x


### PR DESCRIPTION
When run under the SLURM job scheduler, $HOSTNAME is the hostname
of the job on which the job was submitted (ie where srun was invoked),
not the hostname of the node on which zfsstress is running.

This doesn't affect zfsstress in the normal situation of ZFS testing,
but does affect it when in use for testing lustre.

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>